### PR TITLE
Improve performance of GetBytes

### DIFF
--- a/RandomBenchmark/RandomBenchmark/XorShiftRandom.cs
+++ b/RandomBenchmark/RandomBenchmark/XorShiftRandom.cs
@@ -55,17 +55,24 @@ namespace RandomBenchmark
             if (buffer == null)
                 throw new ArgumentNullException(nameof(buffer));
 
-            var tmp = BitConverter.GetBytes(InternalSample());
-            short index = 0;
-            for (var i = 0; i < buffer.Length; ++i)
+            int sample;
+            for (var i = 0; i < buffer.Length;)
             {
-                if (index == 4)
-                {
-                    index = 0;
-                    tmp = BitConverter.GetBytes(InternalSample());
-                }
+                sample = InternalSample();
 
-                buffer[i] = tmp[index++];
+                buffer[i++] = (byte)sample;
+
+                if (i >= buffer.Length)
+                    return;
+                buffer[i++] = (byte)(sample >> 8);
+
+                if (i >= buffer.Length)
+                    return;
+                buffer[i++] = (byte)(sample >> 16);
+
+                if (i >= buffer.Length)
+                    return;
+                buffer[i++] = (byte)(sample >> 24);
             }
         }
 


### PR DESCRIPTION
Use bitwise shifts to avoid allocations and improve performance in GetBytes
```
// * Summary *

Host Process Environment Information:
BenchmarkDotNet.Core=v0.9.9.0
OS=Microsoft Windows NT 6.2.9200.0
Processor=Intel(R) Core(TM) i7-6700HQ CPU 2.60GHz, ProcessorCount=8
Frequency=2531248 ticks, Resolution=395.0620 ns, Timer=TSC
CLR=MS.NET 4.0.30319.42000, Arch=64-bit RELEASE [RyuJIT]
GC=Concurrent Workstation
JitModules=clrjit-v4.6.1586.0

Type=BenchmarkNextBytes  Mode=Throughput  Platform=X64
Jit=RyuJit

       Method |    Median |    StdDev | Scaled | Scaled-SD |  Gen 0 | Gen 1 | Gen 2 | Bytes Allocated/Op |
------------- |---------- |---------- |------- |---------- |------- |------ |------ |------------------- |
   WithRandom | 9.8994 us | 0.0785 us |   1.00 |      0.00 | 198.00 |     - |     - |             447.56 |
 WithXorShift | 1.8067 us | 0.1004 us |   0.19 |      0.01 | 213.89 |     - |     - |             447.27 |
 WithXorShiRo | 2.4583 us | 0.0240 us |   0.25 |      0.00 | 218.37 |     - |     - |             456.40 |
```